### PR TITLE
fix: update to capepy v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ clean_obj_key = etl_job.parameters["OBJECT_KEY"].replace(".pdf", ".csv")
 
 # the response should contain a StreamingBody object that needs to be converted
 # to a file like object to make the pdf libraries happy
-f = io.BytesIO(etl_job.get_raw_file())
+f = io.BytesIO(etl_job.get_src_file())
 
 try:
     # get the report date from the 4th line of the pdf
@@ -65,4 +65,4 @@ interim["Date Reported"] = date_reported
 # write out the transformed data
 with io.StringIO() as csv_buff:
     interim.to_csv(csv_buff, index=False)
-    etl_job.write_clean_file(csv_buff.getvalue(), clean_obj_key)
+    etl_job.write_sink_file(csv_buff.getvalue(), clean_obj_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws-glue-libs @ git+https://github.com/awslabs/aws-glue-libs@9d8293962e6ffc607e5dc328e246f40b24010fa8
 boto3==1.34.103
-capepy>=1.0.0,<2.0.0
+capepy>=2.0.0,<3.0.0
 pandas==2.2.2
 pyspark==3.5.1
 python-docx==1.1.2


### PR DESCRIPTION
This updates the ETL script to use the latest tooling from the `capepy` library which recently had a refactor to generalize the names of some of the functions